### PR TITLE
README.md: remove --no-site-packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ is similar to one from the [OpenFOAM](https://www.openfoam.com/) library.
 1. Clone the directory with `git clone git@github.com:iBatistic/HoPyFVM.git`
 2. Required python are listed in `requirements.txt` and can be installed easily with `venv`:  
     ```
-    virtualenv --no-site-packages venv-HoPyFoam
+    virtualenv venv-HoPyFoam
     source venv-HoPyFoam/bin/activate
     pip install -r requirements.txt
     ```


### PR DESCRIPTION
This command `virtualenv --no-site-packages venv-HoPyFoam` gives the error
```
virtualenv: error: unrecognized arguments: --no-site-packages
```
According to https://stackoverflow.com/questions/60783788/virtualenv-virtualenvwrapper-virtualenv-error-unrecognized-arguments-no-sit, it seems that this option is no longer required. FYI, my version of `virtualenv` is version `20.25.0`.

So, it seems that it can be removed.